### PR TITLE
Use setTimeout instead of setImmediate

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -5,8 +5,7 @@ var UglifyJS = require("uglify-js");
 var full = fs.readFileSync("promiscuous.js", "utf8");
 var copyright = full.match(/.*\n/)[0];
 var minified = copyright + UglifyJS.minify(full, { fromString: true }).code;
-var browserFull = full.replace("module.exports", "window.Promise")
-                      .replace("setImmediate", "setTimeout");
+var browserFull = full.replace("module.exports", "window.Promise");
 var browser = copyright + UglifyJS.minify(browserFull, { fromString: true }).code
                                   .replace("window.Promise", "Promise");
 

--- a/promiscuous.js
+++ b/promiscuous.js
@@ -75,7 +75,7 @@
 
   // Finalizes the promise by resolving/rejecting it with the transformed value
   function finalize(promise, resolve, reject, value, transform) {
-    setImmediate(function () {
+    setTimeout(function () {
       try {
         // Transform the value through and check whether it's a promise
         value = transform(value);


### PR DESCRIPTION
This might be controversial. I tried to use this module with Browserify and Safari today, but it broke because Safari (along with many other browsers) does not support `setImmediate`.

I know this will be slower than `setImmediate`, but I see this greatest use for this module in the browser where a lightweight shim is very valuable. In Node the size of the library is less of a concern because the end users don't need to download anything.

I couldn't see a good way of supporting both without either a) building a setTimeout version for Browserify and and using the `browser` field of `package.json` b) increasing the size of the library.

Let me know what you think.
