### PR TITLE
Add support for more input variations to `Promise.all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,19 @@ var promises = [promiseLater(1), promiseLater(2), promiseLater(3)];
 Promise.all(promises).then(function (values) { console.log(values); });
 /* [1, 2, 3] */
 ```
+
+### Deferred
+Promise(resolve, reject) function should be preferred, but if you need an instance for `promise`, `resolve` and `reject`, you can use `Promise.defer`.
+
+```javascript
+function deferredFunction() {
+  var deferred = Promise.defer();
+  setTimeout(function () {
+    if (something)
+      deferred.resolve(something);
+    else
+      deferred.reject(new Error("nothing"));
+  }, 1000);
+  return deferred.promise;
+}
+```

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   },
   "main": "promiscuous.js",
   "scripts": {
-    "test": "promises-aplus-tests test/adapter"
+    "test": "promises-aplus-tests test/adapter && mocha -R spec"
   },
   "devDependencies": {
     "promises-aplus-tests": "2.0.x",
-    "uglify-js": "2.2.x"
+    "uglify-js": "2.2.x",
+    "mocha": "^1.18.2"
   }
 }

--- a/promiscuous.js
+++ b/promiscuous.js
@@ -128,4 +128,14 @@
       });
     });
   };
+
+  // Creates a deferred object wrapping a promise
+  Promise.defer = function () {
+    var deferred = {};
+    deferred.promise = new Promise(function (resolve, reject) {
+      deferred.resolve = resolve;
+      deferred.reject = reject;
+    });
+    return deferred;
+  };
 })('f', 'o');

--- a/promiscuous.js
+++ b/promiscuous.js
@@ -106,18 +106,22 @@
 
   // Transforms an array of promises into a promise for an array
   Promise.all = function (promises) {
+    // support for promises array
+    if (promises.then) return promises.then(function (value) { return Promise.all(value); });
     return Promise(function (resolve, reject, count, values) {
       // Array of collected values
       values = [];
       // Resolve immediately if there are no promises
       count = promises.length || resolve(values);
+      // If not iterable, resolve as-is
+      if (!promises.map) return resolve(promises);
       // Transform all elements (`map` is shorter than `forEach`)
       promises.map(function (promise, index) {
         ResolvedPromise(promise).then(
           // Store the value and resolve if it was the last
           function (value) {
             values[index] = value;
-            --count || resolve(values);
+            index === (count - 1) && resolve(values);
           },
           // Reject if one element fails
           reject);

--- a/test/test-extended-api.js
+++ b/test/test-extended-api.js
@@ -2,7 +2,7 @@
 /* global describe, it */
 var assert = require('assert');
 var Promise = require('../promiscuous');
-var fail = Promise.reject(new Error('promise expected to resolved'));
+var fail = Promise.reject(new Error('invalid promise resolution'));
 var bindCallback = function (p, callback) {
   return p.then(function (result) { callback(undefined, result); }, callback.bind(null));
 };
@@ -15,7 +15,8 @@ describe('Extended API', function () {
       bindCallback(Promise.all([]).then(
         function (result) {
           assert.deepEqual(result, []);
-        }, fail
+        },
+        fail
       ), done);
     });
     it('should resolve values array', function (done) {
@@ -23,7 +24,8 @@ describe('Extended API', function () {
       bindCallback(Promise.all(input).then(
         function (results) {
           assert.deepEqual(results, input);
-        }, fail
+        },
+        fail
       ), done);
     });
     it('should resolve promises array', function (done) {
@@ -31,7 +33,8 @@ describe('Extended API', function () {
       bindCallback(Promise.all(input).then(
         function (results) {
           assert.deepEqual(results, [1, 2, 3]);
-        }, fail
+        },
+        fail
       ), done);
     });
     it('should resolve sparse array input', function (done) {
@@ -39,7 +42,8 @@ describe('Extended API', function () {
       bindCallback(Promise.all(input).then(
         function (results) {
           assert.deepEqual(results, input);
-        }, fail
+        },
+        fail
       ), done);
     });
     it('should reject if any input promise rejects', function (done) {
@@ -58,7 +62,8 @@ describe('Extended API', function () {
       bindCallback(Promise.all(input).then(
         function (results) {
           assert.deepEqual(results, expected);
-        }, fail
+        },
+        fail
       ), done);
     });
     it('should resolve to empty array when input promise does not resolve to array', function (done) {
@@ -68,6 +73,140 @@ describe('Extended API', function () {
         },
         fail
       ), done);
+    });
+  });
+  // test suite borrowed from cujojs/when
+  // source: https://github.com/cujojs/when/blob/master/test/defer-test.js
+  describe.only('Promise.defer', function () {
+    var sentinel = {};
+    function fakeResolved(val) {
+      return {
+        then: function (callback) {
+          return fakeResolved(callback ? callback(val) : val);
+        }
+      };
+    }
+    function fakeRejected(reason) {
+      return {
+        then: function (callback, errback) {
+          return errback ? fakeResolved(errback(reason)) : fakeRejected(reason);
+        }
+      };
+    }
+    describe('resolve', function () {
+      it('should fulfill with an immediate value', function (done) {
+        var d = Promise.defer();
+
+        bindCallback(d.promise.then(
+          function (val) {
+            assert.strictEqual(val, sentinel);
+          },
+          fail
+        ), done);
+
+        d.resolve(sentinel);
+      });
+      it('should fulfill with fulfilled promised', function (done) {
+        var d = Promise.defer();
+
+        bindCallback(d.promise.then(
+          function (val) {
+            assert.strictEqual(val, sentinel);
+          },
+          fail
+        ), done);
+
+        d.resolve(fakeResolved(sentinel));
+      });
+
+      it('should reject with rejected promise', function (done) {
+        var d = Promise.defer();
+
+        bindCallback(d.promise.then(
+          fail,
+          function (val) {
+            assert.strictEqual(val, sentinel);
+          }
+        ), done);
+
+        d.resolve(fakeRejected(sentinel));
+      });
+
+      it('should invoke newly added callback when already resolved', function (done) {
+        var d = Promise.defer();
+
+        d.resolve(sentinel);
+
+        bindCallback(d.promise.then(
+          function (val) {
+            assert.strictEqual(val, sentinel);
+          },
+          fail
+        ), done);
+      });
+    });
+    describe('reject', function () {
+      it('should reject with an immediate value', function (done) {
+        var d = Promise.defer();
+
+        bindCallback(d.promise.then(
+          fail,
+          function (val) {
+            assert.strictEqual(val, sentinel);
+          }
+        ), done);
+
+        d.reject(sentinel);
+      });
+
+      it('should reject with fulfilled promised', function (done) {
+        var d, expected;
+
+        d = Promise.defer();
+        expected = fakeResolved(sentinel);
+
+        bindCallback(d.promise.then(
+          fail,
+          function (val) {
+            assert.strictEqual(val, expected);
+          }
+        ), done);
+
+        d.reject(expected);
+      });
+
+      it('should reject with rejected promise reason', function (done) {
+
+        var d, expected;
+
+        d = Promise.defer();
+        expected = fakeRejected(sentinel);
+
+        bindCallback(d.promise.then(
+          fail,
+          function (val) {
+            // variation from `when` to `promiscuous`:
+            // rejecting with a rejected promise returns the reason, not the rejected promise
+            // assert.strictEqual(val, expected);
+            assert.strictEqual(val, sentinel);
+          }
+        ), done);
+
+        d.reject(expected);
+      });
+
+      it('should invoke newly added errback when already rejected', function (done) {
+        var d = Promise.defer();
+
+        d.reject(sentinel);
+
+        bindCallback(d.promise.then(
+          fail,
+          function (val) {
+            assert.equal(val, sentinel);
+          }
+        ), done);
+      });
     });
   });
 });

--- a/test/test-extended-api.js
+++ b/test/test-extended-api.js
@@ -1,0 +1,73 @@
+/* jshint strict:false */
+/* global describe, it */
+var assert = require('assert');
+var Promise = require('../promiscuous');
+var fail = Promise.reject(new Error('promise expected to resolved'));
+var bindCallback = function (p, callback) {
+  return p.then(function (result) { callback(undefined, result); }, callback.bind(null));
+};
+
+describe('Extended API', function () {
+  // test suite borrowed from cujojs/when
+  // source: https://github.com/cujojs/when/blob/master/test/all-test.js
+  describe('Promise.all', function () {
+    it('should resolve empty input', function (done) {
+      bindCallback(Promise.all([]).then(
+        function (result) {
+          assert.deepEqual(result, []);
+        }, fail
+      ), done);
+    });
+    it('should resolve values array', function (done) {
+      var input = [1, 2, 3];
+      bindCallback(Promise.all(input).then(
+        function (results) {
+          assert.deepEqual(results, input);
+        }, fail
+      ), done);
+    });
+    it('should resolve promises array', function (done) {
+      var input = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+      bindCallback(Promise.all(input).then(
+        function (results) {
+          assert.deepEqual(results, [1, 2, 3]);
+        }, fail
+      ), done);
+    });
+    it('should resolve sparse array input', function (done) {
+      var input = [, 1, , 1, 1, ];
+      bindCallback(Promise.all(input).then(
+        function (results) {
+          assert.deepEqual(results, input);
+        }, fail
+      ), done);
+    });
+    it('should reject if any input promise rejects', function (done) {
+      var input = [Promise.resolve(1), Promise.reject(2), Promise.resolve(3)];
+      bindCallback(Promise.all(input).then(
+        fail,
+        function (failed) {
+          assert.equal(failed, 2);
+        }
+      ), done);
+    });
+    it('should accept a promise for an array', function (done) {
+      var expected, input;
+      expected = [1, 2, 3];
+      input = Promise.resolve(expected);
+      bindCallback(Promise.all(input).then(
+        function (results) {
+          assert.deepEqual(results, expected);
+        }, fail
+      ), done);
+    });
+    it('should resolve to empty array when input promise does not resolve to array', function (done) {
+      bindCallback(Promise.all(Promise.resolve(1)).then(
+        function (result) {
+          assert.deepEqual(result, []);
+        },
+        fail
+      ), done);
+    });
+  });
+});


### PR DESCRIPTION
`Promise.all` support for promises array, sparse array and non-array
input. Borrowed test suite from cujojs/when.
