### PR TITLE
Making IE8 parse promiscuous.js

### DIFF
--- a/promiscuous.js
+++ b/promiscuous.js
@@ -67,7 +67,7 @@
 
     // Create and return the promise (reusing the callback variable)
     callback.call(callback = { then:  function (resolved, rejected) { return handler(resolved, rejected); },
-                               catch: function (rejected)           { return handler(0,        rejected); } },
+                               "catch": function (rejected)           { return handler(0,        rejected); } },
                   function (value)  { handler(is, 1,  value); },
                   function (reason) { handler(is, 0, reason); });
     return callback;


### PR DESCRIPTION
`catch` is a reserved word and IE8 hates when you use these as keys in objects unquoted. I'm not sure if this makes promises themselves work in IE8, but for my purposes it's enough (I'm rendering a dialog that IE8 is unsupported - adding quotes avoids a parsing error).

Related: https://github.com/RubenVerborgh/promiscuous/issues/22
