### PR TITLE
Fallback to setTimeout if setImmediate isn't supported

### DIFF
--- a/promiscuous.js
+++ b/promiscuous.js
@@ -75,7 +75,7 @@
 
   // Finalizes the promise by resolving/rejecting it with the transformed value
   function finalize(promise, resolve, reject, value, transform) {
-    setImmediate(function () {
+    (setImmediate || setTimeout)(function () {
       try {
         // Transform the value through and check whether it's a promise
         value = transform(value);


### PR DESCRIPTION
`setImmediate` isn't supported by most browsers (see: https://developer.mozilla.org/en/docs/Web/API/Window/setImmediate)

This allows the promiscuous library to be used in browsers without the common workaround of `window.setImmediate = setTimeout`