### PR TITLE
cache setImidiate on init to avoid overriding

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -5,11 +5,13 @@ var UglifyJS = require("uglify-js");
 var full = fs.readFileSync("promiscuous.js", "utf8");
 var copyright = full.match(/.*\n/)[0];
 var minified = copyright + UglifyJS.minify(full, { fromString: true }).code;
-var browserFull = full.replace("module.exports", "window.Promise")
-                      .replace("setImmediate", "setTimeout");
+var browserFull = full.replace(/module\.exports/g, "window.Promise")
+                      .replace(/setImmediateCached/g, "setTimeoutCached")
+                      .replace(/setImmediate/g, "setTimeout");
 var browser = copyright + UglifyJS.minify(browserFull, { fromString: true }).code
-                                  .replace("window.Promise", "Promise");
-var browserShimFull = full.replace("setImmediate", "setTimeout");
+                                  .replace(/window\.Promise/g, "Promise");
+var browserShimFull = full.replace(/setImmediateCached/g, "setTimeoutCached")
+                          .replace(/setImmediate/g, "setTimeout");
 
 var path = "dist/";
 if(!fs.existsSync(path))

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.1.2"
       }
     },
     "glob": {
@@ -52,9 +52,9 @@
       "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
       "dev": true,
       "requires": {
-        "graceful-fs": "~2.0.0",
-        "inherits": "2",
-        "minimatch": "~0.2.11"
+        "graceful-fs": "2.0.3",
+        "inherits": "2.0.3",
+        "minimatch": "0.2.14"
       }
     },
     "graceful-fs": {
@@ -100,9 +100,9 @@
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.3.tgz",
+      "integrity": "sha512-UadvxZrQFjGyDTHL8yP4bUwmdSfkkBIWFGoM2uFUZUCoSs1ghgnqmBft1iF1K1Q1+2Am1HDvUXhhD/Am2YmCag==",
       "dev": true
     },
     "lru-cache": {
@@ -117,8 +117,8 @@
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "dev": true,
       "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
       }
     },
     "minimist": {
@@ -164,7 +164,7 @@
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "dev": true,
       "requires": {
-        "wordwrap": "~0.0.2"
+        "wordwrap": "0.0.3"
       }
     },
     "promises-aplus-tests": {
@@ -173,9 +173,9 @@
       "integrity": "sha1-NZtbU020uEFu3C32Zd1yZw4p2zk=",
       "dev": true,
       "requires": {
-        "mocha": "~1.21.4",
-        "sinon": "^1.10.3",
-        "underscore": "~1.6.0"
+        "mocha": "1.21.5",
+        "sinon": "1.17.7",
+        "underscore": "1.6.0"
       }
     },
     "samsam": {
@@ -199,7 +199,15 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "util": "0.11.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.3.2",
+          "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -208,7 +216,7 @@
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "uglify-js": {
@@ -217,8 +225,8 @@
       "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
       "dev": true,
       "requires": {
-        "optimist": "~0.3.5",
-        "source-map": "~0.1.7"
+        "optimist": "0.3.7",
+        "source-map": "0.1.43"
       }
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   },
   "main": "promiscuous.js",
   "scripts": {
-    "test": "promises-aplus-tests test/adapter"
+    "test": "promises-aplus-tests test/adapter && node test/test-lolex.js"
   },
   "devDependencies": {
+    "lolex": "^2.7.3",
     "promises-aplus-tests": "2.0.x",
     "uglify-js": "2.2.x"
   }

--- a/promiscuous.js
+++ b/promiscuous.js
@@ -1,5 +1,7 @@
 /**@license MIT-promiscuous-©Ruben Verborgh*/
 (function (func, obj) {
+  // cache setImmediate to avoid overriding
+  var setImmediateCached = setImmediate;
   // Type checking utility function
   function is(type, item) { return (typeof item)[0] == type; }
 
@@ -76,7 +78,7 @@
 
   // Finalizes the promise by resolving/rejecting it with the transformed value
   function finalize(promise, resolve, reject, value, transform) {
-    setImmediate(function () {
+    setImmediateCached(function () {
       try {
         // Transform the value through and check whether it's a promise
         value = transform(value);

--- a/test/test-lolex.js
+++ b/test/test-lolex.js
@@ -1,0 +1,15 @@
+var lolex = require('lolex');
+var assert = require('assert');
+var Promise = require('../promiscuous');
+
+var resolved = false;
+
+setTimeout(function() {
+    assert.ok(resolved, 'Promise should resolve when lolex is installed');
+}, 500);
+
+lolex.install();
+Promise.resolve()
+    .then(function() {
+        resolved = true;
+    });


### PR DESCRIPTION
Popular library for faking timeouts for testing purposes [lolex](https://github.com/sinonjs/lolex) (used by sinon) fakes global methods (`setTimeout` && `setImmediate`).

This fake brakes `promiscuous` and other promise polyfills based on setTimeout (see an issue https://github.com/sinonjs/lolex/pull/105) in sinon tests in environments without native promises (like IE11).

This PR fixes this problem: `setImmediate` is now cached on init so `lolex` does not influence the work of polyfill.

I've also added a test script `test/test-lolex.js` for this behavior.